### PR TITLE
feat: modern purple single-page styling

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2,3 +2,51 @@
  * Enter any custom CSS here.
  * This file will not be overwritten by theme updates.
 */
+
+html {
+  scroll-behavior: smooth;
+}
+
+/* Purple themed hero */
+.hero {
+  color: #fff;
+}
+
+.hero .bg-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(126,91,239,0.9), rgba(168,85,247,0.8));
+}
+
+.hero .content {
+  background: rgba(0,0,0,0.25);
+  padding: 2rem;
+  border-radius: 1rem;
+}
+
+/* Rounded navbar pod */
+.navbar {
+  background: rgba(126,91,239,0.85);
+  backdrop-filter: blur(10px);
+  border-radius: 50px;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
+}
+
+.navbar .nav-link {
+  border-radius: 50px;
+  color: #fff !important;
+  padding: 0.5rem 1rem;
+}
+
+.navbar .nav-link:hover {
+  background: rgba(255,255,255,0.1);
+}
+
+.navbar .btn {
+  border-radius: 50px;
+}
+
+.navbar .navbar-brand span {
+  color: #fff;
+}

--- a/components/faq.njk
+++ b/components/faq.njk
@@ -1,4 +1,4 @@
-<section class="py-20 faq bg-block-{{ properties.background }} component" data-component-id="{{ componentId }}">
+<section id="faq" class="py-20 faq bg-block-{{ properties.background }} component" data-component-id="{{ componentId }}">
   <div class="container">
     {% if properties.title %}
     <div class="section-title">

--- a/components/features.njk
+++ b/components/features.njk
@@ -1,4 +1,4 @@
-<section class="container py-20 features component" data-component-id="{{ componentId }}">
+<section id="features" class="container py-20 features component" data-component-id="{{ componentId }}">
   {% if properties.title %}
   <div class="section-title">
     <h2>{{ properties.title | renderString }}</h2>

--- a/components/hero.njk
+++ b/components/hero.njk
@@ -1,4 +1,4 @@
-<section class="hero alignment-{{ properties.alignment }} height-{{ properties.height }} component" style="background-image: url('{{ properties.background_image | imageUrl }}');" data-component-id="{{ componentId }}">
+<section id="home" class="hero alignment-{{ properties.alignment }} height-{{ properties.height }} component" style="background-image: url('{{ properties.background_image | imageUrl }}');" data-component-id="{{ componentId }}">
   <div class="bg-overlay"></div>
   <div class="container">
     <div class="content">

--- a/components/navbar.njk
+++ b/components/navbar.njk
@@ -53,19 +53,19 @@
 
 <style>
   .navbar-nav .nav-link:hover {
-    color: red;
+    color: var(--cl-primary);
     text-decoration: underline;
-  	text-underline-offset: 5px;
+    text-underline-offset: 5px;
   }
-  
+
   .navbar {
-  	transition: top 0.3s ease;
+    transition: top 0.3s ease;
   }
 
   .navbar-nav .nav-link.active {
     text-decoration: underline;
-  	text-underline-offset: 5px;
-    color: red;
+    text-underline-offset: 5px;
+    color: var(--cl-primary);
   }
 </style>
 

--- a/settings.default.json
+++ b/settings.default.json
@@ -104,7 +104,7 @@
     },
     "global": {
         "properties": {
-            "theme_color": "#6571FF",
+            "theme_color": "#8a2be2",
             "primary_background_color": "#0C1427",
             "secondary_background_color": "#0A1122",
             "primary_border_color": "#000F26",
@@ -123,7 +123,12 @@
                 "left_links": [
                     {
                         "text": "Home",
-                        "link": "\/",
+                        "link": "\/#home",
+                        "shape": "regular"
+                    },
+                    {
+                        "text": "Features",
+                        "link": "\/#features",
                         "shape": "regular"
                     },
                     {
@@ -132,13 +137,8 @@
                         "shape": "regular"
                     },
                     {
-                        "text": "Status",
-                        "link": "\/status",
-                        "shape": "regular"
-                    },
-                    {
-                        "text": "Feedback",
-                        "link": "\/feedback",
+                        "text": "FAQ",
+                        "link": "\/#faq",
                         "shape": "regular"
                     }
                 ],
@@ -157,20 +157,19 @@
                 "links": [
                     {
                         "text": "Home",
-                        "link": "\/"
+                        "link": "\/#home"
+                    },
+                    {
+                        "text": "Features",
+                        "link": "\/#features"
                     },
                     {
                         "text": "Products",
                         "link": "\/#products"
                     },
                     {
-                        "text": "Feedback",
-                        "link": "\/feedback"
-                    },
-                    {
-                        "text": "Status",
-                        "link": "\/status",
-                        "shape": "regular"
+                        "text": "FAQ",
+                        "link": "\/#faq"
                     },
                     {
                         "text": "Terms of Service",

--- a/settings.json
+++ b/settings.json
@@ -104,7 +104,7 @@
     },
     "global": {
         "properties": {
-            "theme_color": "#ff0000",
+            "theme_color": "#8a2be2",
             "primary_background_color": "#000000",
             "secondary_background_color": "#121212db",
             "primary_border_color": "#000000",
@@ -124,7 +124,12 @@
                 "left_links": [
                     {
                         "text": "Home",
-                        "link": "\/",
+                        "link": "\/#home",
+                        "shape": "regular"
+                    },
+                    {
+                        "text": "Features",
+                        "link": "\/#features",
                         "shape": "regular"
                     },
                     {
@@ -133,13 +138,8 @@
                         "shape": "regular"
                     },
                     {
-                        "text": "Status",
-                        "link": "\/status",
-                        "shape": "regular"
-                    },
-                    {
-                        "text": "Feedback",
-                        "link": "\/feedback",
+                        "text": "FAQ",
+                        "link": "\/#faq",
                         "shape": "regular"
                     }
                 ],
@@ -158,20 +158,19 @@
                 "links": [
                     {
                         "text": "Home",
-                        "link": "\/"
+                        "link": "\/#home"
+                    },
+                    {
+                        "text": "Features",
+                        "link": "\/#features"
                     },
                     {
                         "text": "Products",
                         "link": "\/#products"
                     },
                     {
-                        "text": "Feedback",
-                        "link": "\/feedback"
-                    },
-                    {
-                        "text": "Status",
-                        "link": "\/status",
-                        "shape": "regular"
+                        "text": "FAQ",
+                        "link": "\/#faq"
                     },
                     {
                         "text": "Terms of Service",


### PR DESCRIPTION
## Summary
- implement smooth scrolling and purple gradient hero with rounded navbar
- add section anchors for one-page navigation
- switch default theme color and navigation links to purple single-page layout

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2935a6c832dbbb4f3a139c52b24